### PR TITLE
Issue #7 fix

### DIFF
--- a/check_channel_sensitivity.py
+++ b/check_channel_sensitivity.py
@@ -123,6 +123,7 @@ try:
                 reset_cycles=chip.config.reset_cycles)
                                                                      
             board_results += [chip_results]
+            larpix_scripting.clear_stored_packets(controller)
             finish_time = time.time()
             if verbose:
                 log.debug('%d-c%d sensitivity test took %.2f s' % \

--- a/check_leakage.py
+++ b/check_leakage.py
@@ -112,6 +112,7 @@ try:
                                                             trim=pixel_trim,
                                                             run_time=run_time)
             board_results += [chip_results]
+            larpix_scripting.clear_stored_packets(controller)
             finish_time = time.time()
             if verbose:
                 log.debug('%d-c%d leakage test took %.2f s' % \

--- a/check_pedestal_width_internal_pulser.py
+++ b/check_pedestal_width_internal_pulser.py
@@ -193,6 +193,7 @@ try:
 
             board_results += [chip_results]
             controller.disable(chip_id=chip_id, io_chain=io_chain)
+            larpix_scripting.clear_stored_packets(controller)
             finish_time = time.time()
             if verbose:
                 log.debug('%d-c%d pedestal scan took %.2f s' % \

--- a/check_pedestal_width_low_threshold.py
+++ b/check_pedestal_width_low_threshold.py
@@ -105,6 +105,7 @@ try:
                                                                     global_threshold,
                                                                 run_time=run_time)
             board_results += [chip_results[1:]]
+            larpix_scripting.clear_stored_packets(controller)
             finish_time = time.time()
             if verbose:
                 log.debug('%d-c%d pedestal scan took %.2f s' % \

--- a/configure_chips.py
+++ b/configure_chips.py
@@ -132,6 +132,7 @@ try:
                 if not chip_id in chips_to_scan:
                     log.info('skipping %d-c%d' % chip_info)
                     continue
+
             global_threshold = global_threshold_max
             chip.config.global_threshold = global_threshold
             pixel_trims = [pixel_trim_max]*32
@@ -334,6 +335,7 @@ try:
             # Disable chip for rest of loop
             controller.disable(chip_id=chip_id, io_chain=io_chain)
             log.info('%d-c%d configuration complete' % chip_info)
+            larpix_scripting.clear_stored_packets(controller)
             finish_time = time.time()
             if verbose:
                 log.debug('%d-c%d configuration took %.2f s' % \

--- a/helpers/larpix_scripting.py
+++ b/helpers/larpix_scripting.py
@@ -4,6 +4,11 @@ import larpix.larpix as larpix
 from helpers.script_logging import ScriptLogger
 log = ScriptLogger.get_script_log()
 
+def clear_stored_packets(controller):
+    for chip in controller.chips:
+        chip.reads = []
+    controller.reads = []
+
 def clear_buffer_quick(controller, run_time=0.05):
     '''Open serial comms for run_time seconds'''
     controller.run(run_time,'clear buffer (quick)')

--- a/setup-larpix-scripts.sh
+++ b/setup-larpix-scripts.sh
@@ -16,10 +16,10 @@ print(make_default_board(localtime(), '$1', force=True))"
 fi
 
 echo "creating aliases..."
-alias larpix-check-pedestal="python $LARPIX_SCRIPT_DIR/run_pedestal_scan.py"
-alias larpix-check-leakage="python $LARPIX_SCRIPT_DIR/run_leakage.py"
-alias larpix-configure="python $LARPIX_SCRIPT_DIR/run_configure_chips.py"
-alias larpix-check-sensitivity="python $LARPIX_SCRIPT_DIR/run_channel_sensitivity.py"
+alias larpix-check-pedestal="python $LARPIX_SCRIPT_DIR/check_pedestal_width_low_threshold.py"
+alias larpix-check-leakage="python $LARPIX_SCRIPT_DIR/check_leakage.py"
+alias larpix-configure="python $LARPIX_SCRIPT_DIR/configure_chips.py"
+alias larpix-check-sensitivity="python $LARPIX_SCRIPT_DIR/check_channel_sensitivity.py"
 alias larpix-run="python $LARPIX_SCRIPT_DIR/collect_data.py"
 
 echo "done"


### PR DESCRIPTION
Appears that memory issue was simply due to `larpix.controller` keeping all the packets in memory. Easy fix was to make a `clear_stored_packets` method in `helpers.larpix_scripting` that clears both `chip.reads` and `controller.reads` for a given controller.

This has been tested using a low threshold pedestal run - memory usage increases to about 15% on each chip, but is reset to 4% after each call to `clear_stored_packets`.